### PR TITLE
Add date filter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+  - "3.6"
+  - "3.7-dev"
+sudo: false
+install:
+  - pip install pipenv
+  - pipenv install --dev
+  - echo 'export PYTHONPATH=${PYTHONPATH}:.' > .env
+script:
+  - pipenv run pycodestyle .
+  - pipenv run flake8
+  - pipenv run pytest -v .

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,8 @@ pycodestyle = "*"
 pytest = "*"
 
 [packages]
+click = "*"
+picot = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,116 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "d98382ceddbd6c91e8562d35b14c05989a6d05e6008b98b1749572b93e34e9cf"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.6"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {},
+    "develop": {
+        "atomicwrites": {
+            "hashes": [
+                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
+                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
+            ],
+            "version": "==1.3.0"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+            ],
+            "version": "==19.1.0"
+        },
+        "autopep8": {
+            "hashes": [
+                "sha256:33d2b5325b7e1afb4240814fe982eea3a92ebea712869bfd08b3c0393404248c"
+            ],
+            "index": "pypi",
+            "version": "==1.4.3"
+        },
+        "entrypoints": {
+            "hashes": [
+                "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19",
+                "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"
+            ],
+            "version": "==0.3"
+        },
+        "flake8": {
+            "hashes": [
+                "sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661",
+                "sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8"
+            ],
+            "index": "pypi",
+            "version": "==3.7.7"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:0125e8f60e9e031347105eb1682cef932f5e97d7b9a1a28d9bf00c22a5daef40",
+                "sha256:590044e3942351a1bdb1de960b739ff4ce277960f2425ad4509446dbace8d9d1"
+            ],
+            "markers": "python_version > '2.7'",
+            "version": "==6.0.0"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:19ecf9ce9db2fce065a7a0586e07cfb4ac8614fe96edf628a264b1c70116cf8f",
+                "sha256:84d306a647cc805219916e62aab89caa97a33a1dd8c342e87a37f91073cd4746"
+            ],
+            "version": "==0.9.0"
+        },
+        "py": {
+            "hashes": [
+                "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
+                "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
+            ],
+            "version": "==1.8.0"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
+                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
+            ],
+            "index": "pypi",
+            "version": "==2.5.0"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0",
+                "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"
+            ],
+            "version": "==2.1.1"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:592eaa2c33fae68c7d75aacf042efc9f77b27c08a6224a4f59beab8d9a420523",
+                "sha256:ad3ad5c450284819ecde191a654c09b0ec72257a2c711b9633d677c71c9850c4"
+            ],
+            "index": "pypi",
+            "version": "==4.3.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
+        }
+    }
+}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d98382ceddbd6c91e8562d35b14c05989a6d05e6008b98b1749572b93e34e9cf"
+            "sha256": "be9c7b7bb7e7d46794858fda704a626bed7762a08574a9d241395e0df772c98e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -15,7 +15,31 @@
             }
         ]
     },
-    "default": {},
+    "default": {
+        "click": {
+            "hashes": [
+                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
+                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+            ],
+            "index": "pypi",
+            "version": "==7.0"
+        },
+        "feedparser": {
+            "hashes": [
+                "sha256:bd030652c2d08532c034c27fcd7c85868e7fa3cb2b17f230a44a6bbc92519bf9",
+                "sha256:cd2485472e41471632ed3029d44033ee420ad0b57111db95c240c9160a85831c",
+                "sha256:ce875495c90ebd74b179855449040003a1beb40cd13d5f037a0654251e260b02"
+            ],
+            "version": "==5.2.1"
+        },
+        "picot": {
+            "hashes": [
+                "sha256:66acbfb62df537d34de6cbcad8c3030a5064373b917353d7dd14aebc80a4a947"
+            ],
+            "index": "pypi",
+            "version": "==0.1.0"
+        }
+    },
     "develop": {
         "atomicwrites": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -13,5 +13,10 @@ pip install puput
 
 Puput is intended to be used as a command:
 ```bash
-$ puput
+$ puput <RSS URL>
+```
+
+The option `--to-date` limits the output to entries published in the last 24h:
+```bash
+$ puput --to-date <RSS URL>
 ```

--- a/bin/puput
+++ b/bin/puput
@@ -10,7 +10,7 @@ from puput import date_filter
 @click.option('--to-date', is_flag=True)
 @click.argument('url', nargs=1)
 def collect(url, to_date):
-    """This collects all messages for url."""
+    """This collects all messages for url applying the filter if defined."""
     def filter_func(_): return True
     if to_date:
         filter_func = date_filter

--- a/bin/puput
+++ b/bin/puput
@@ -1,3 +1,21 @@
 #!/usr/bin/env python
 
-print('This is puput')
+import click
+
+import picot.feed
+from puput import date_filter
+
+
+@click.command()
+@click.argument('url', nargs=1)
+def collect(url):
+    """This collects all messages for url."""
+    entries = picot.feed.Feed(
+        url,
+    )
+    for entry in entries:
+        print(entry['title'])
+
+
+if __name__ == '__main__':
+    collect()

--- a/bin/puput
+++ b/bin/puput
@@ -7,11 +7,16 @@ from puput import date_filter
 
 
 @click.command()
+@click.option('--to-date', is_flag=True)
 @click.argument('url', nargs=1)
-def collect(url):
+def collect(url, to_date):
     """This collects all messages for url."""
+    def filter_func(_): return True
+    if to_date:
+        filter_func = date_filter
     entries = picot.feed.Feed(
         url,
+        filter_func=filter_func,
     )
     for entry in entries:
         print(entry['title'])

--- a/puput/__init__.py
+++ b/puput/__init__.py
@@ -1,0 +1,14 @@
+import datetime
+
+
+def date_filter(entry):
+    """This function returns True if the entry's published date is newer
+    than one day."""
+
+    now = datetime.datetime.now()
+    interval = datetime.timedelta(days=1)
+    entry_published = datetime.datetime.strptime(
+        entry['published'][:-4],
+        '%a, %d %b %Y %H:%M:%S',
+    )
+    return now - entry_published <= interval

--- a/puput/__init__.py
+++ b/puput/__init__.py
@@ -1,3 +1,8 @@
+"""This module provides some functions to puput command.
+
+These functions are mostly helpers and tools to support its options.
+"""
+
 import datetime
 
 

--- a/test/test_puput.py
+++ b/test/test_puput.py
@@ -1,0 +1,2 @@
+def test_sample():
+    assert True

--- a/test/test_puput.py
+++ b/test/test_puput.py
@@ -1,2 +1,67 @@
-def test_sample():
-    assert True
+import datetime
+
+import pytest
+
+import puput
+
+
+today = datetime.datetime(2019, 3, 1, 9, 10, 11, 1234)
+yesterday = 'Thu, 28 Feb 2019 19:10:11 UTC'
+a_week_ago = 'Fri, 22 Feb 2019 19:10:11 UTC'
+yesterday_entry = {
+    'title': 'Some entry',
+    'link': 'https://some.site/entry',
+    'published': yesterday,
+}
+a_week_ago_entry = {
+    'title': 'Some entry',
+    'link': 'https://some.site/entry',
+    'published': a_week_ago,
+}
+original_strptime = datetime.datetime.strptime
+
+
+@pytest.fixture
+def patch_datetime_now(monkeypatch):
+    class mockDatetime(object):
+        @classmethod
+        def now(cls):
+            return today
+
+        @classmethod
+        def strptime(cls, date, format):
+            if date[-4:] == ' UTC':
+                raise ValueError(
+                    "time data '{}' does not match format '{}'".format(
+                        date,
+                        format,
+                    ),
+                )
+            return original_strptime(date, format)
+
+    monkeypatch.setattr(datetime, 'datetime', mockDatetime)
+
+
+@pytest.mark.parametrize(
+    'entry,expected_output',
+    [
+        (
+            yesterday_entry,
+            True,
+        ),
+        (
+            a_week_ago_entry,
+            False,
+        ),
+    ],
+    ids=[
+        'Yesterday entry',
+        'A week ago entry',
+    ],
+)
+def test_date_filter(
+        entry,
+        expected_output,
+        patch_datetime_now,
+):
+    assert(puput.date_filter(entry) == expected_output)


### PR DESCRIPTION
This filter allows the user to filter the entries from the RSS to the published in the last 24h.
This change includes adding the function with its tests, required dependencies, basic entries gathering, option to filter to published in last 24h, and documentation.