### PR TITLE
Add format option, code, and documentation

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ pytest_mock = "*"
 [packages]
 click = "*"
 picot = "*"
+jinja2 = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1aa27ec8b630ba20dfbf7b246b7a2ac1014c563ae67392c3ccedec62ea08267c"
+            "sha256": "fbdbd90b392d9f45faaf763eb712c593265f7060804e289a372f464b43ead108"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -31,6 +31,47 @@
                 "sha256:ce875495c90ebd74b179855449040003a1beb40cd13d5f037a0654251e260b02"
             ],
             "version": "==5.2.1"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013",
+                "sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"
+            ],
+            "index": "pypi",
+            "version": "==2.10.1"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"
+            ],
+            "version": "==1.1.1"
         },
         "picot": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -25,3 +25,8 @@ The option `--title-starts` allows to specify a string the title must start with
 ```bash
 $ puput --title-starts 'Hello' <RSS URL>
 ```
+
+The option `--format` allows to specify a string, using Jinja2 templating system, to format the output based on the entry data:
+```bash
+$ puput --format '{{title}} {{link}}' <RSS URL>
+```

--- a/bin/puput
+++ b/bin/puput
@@ -3,21 +3,23 @@
 import click
 
 import picot.feed
-from puput import filter_generator
+from puput import filter_generator, format_generator
 
 
 @click.command()
 @click.option('--to-date', is_flag=True)
 @click.option('--title-starts', default='')
+@click.option('--format', default='{title}')
 @click.argument('url', nargs=1)
-def collect(url, to_date, title_starts):
+def collect(url, to_date, title_starts, format):
     """This collects all messages for url applying the filter if defined."""
     entries = picot.feed.Feed(
         url,
         filter_func=filter_generator(to_date, title_starts),
+        format_func=format_generator(format),
     )
     for entry in entries:
-        print(entry['title'])
+        print(entry)
 
 
 if __name__ == '__main__':

--- a/puput/__init__.py
+++ b/puput/__init__.py
@@ -5,6 +5,17 @@ These functions are mostly helpers and tools to support its options.
 
 import datetime
 
+from jinja2 import Template
+
+
+def format_generator(format):
+    """This function returns a format function using format."""
+    def format_func(e):
+        t = Template(format)
+        return t.render(e)
+
+    return format_func
+
 
 def filter_generator(to_date, title_starts):
     """This function returns a filter function combining other


### PR DESCRIPTION
The format option will be supporting Jinja2 templating system.
The format function is generated through a generator function in order
to inject the template provided.
The documentation on `README.md` has been updated to reflect the change.

There's no test for the format generator function, since it's too simple to require it.